### PR TITLE
Add download stats, improved HF integration

### DIFF
--- a/src/audiobox_aesthetics/model/aes_wavlm.py
+++ b/src/audiobox_aesthetics/model/aes_wavlm.py
@@ -9,6 +9,8 @@ import logging
 from torch import nn
 import torch
 
+from huggingface_hub import PyTorchModelHubMixin
+
 from .utils import create_mlp_block
 from .wavlm import WavLM, WavLMConfig
 
@@ -72,7 +74,7 @@ AXES_NAME = ["CE", "CU", "PC", "PQ"]
 
 
 @dataclass(eq=False)
-class WavlmAudioEncoderMultiOutput(nn.Module):
+class WavlmAudioEncoderMultiOutput(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/facebookresearch/audiobox-aesthetics", pipeline_tag="audio-classification", license="cc-by-4.0"):
     proj_num_layer: int = 1
     proj_ln: bool = False
     proj_act_fn: str = "gelu"


### PR DESCRIPTION
Hi @androstj,

Thanks for this nice work and making the [model](https://huggingface.co/facebook/audiobox-aesthetics) available on the hub.

I wrote a quick PoC to showcase that you could also enable the following things for your model:

* working download stats
* safetensors for weights serialization, rather than .pt
* load the model automatically using `from_pretrained` (and push them using `push_to_hub`)

It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```python
from .model.aes_wavlm import WavlmAudioEncoderMultiOutput

model = WavlmAudioEncoderMultiOutput.from_pretrained("nielsr/audiobox-demo")

# optionally, one can push a trained model to the hub
model.push_to_hub("nielsr/my-awesome-audiobox-model")
```

Would you be interested in this integration?

Kind regards,

Niels