### PR TITLE
Use module specific logging rather than root-logger for modules

### DIFF
--- a/src/audiobox_aesthetics/infer.py
+++ b/src/audiobox_aesthetics/infer.py
@@ -18,7 +18,8 @@ from .utils import load_model
 
 from .model.aes import AesMultiOutput, Normalize
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+# Create module-level logger instead of configuring root logger
+logger = logging.getLogger(__name__)
 
 
 # STRUCT
@@ -93,10 +94,10 @@ class AesPredictor:
             self.device = torch.device("mps")
         else:
             self.device = torch.device("cpu")
-        logging.info(f"Setting up Aesthetic model on {self.device}")
+        logger.info(f"Setting up Aesthetic model on {self.device}")
 
         if self.checkpoint_pth is not None:
-            logging.info("Using local checkpoint ...")
+            logger.info("Using local checkpoint ...")
             # Original way to load model directly using load_state_dict
             checkpoint_file = load_model(self.checkpoint_pth)
 
@@ -128,7 +129,7 @@ class AesPredictor:
             )
             model.load_state_dict(state_dict)
         else:
-            logging.info("Using HF from_pretrained to load AES model ...")
+            logger.info("Using HF from_pretrained to load AES model ...")
             # load from HF repo (using safetensors)
             model = AesMultiOutput.from_pretrained("facebook/audiobox-aesthetics")
 

--- a/src/audiobox_aesthetics/model/aes.py
+++ b/src/audiobox_aesthetics/model/aes.py
@@ -14,7 +14,7 @@ from .utils import create_mlp_block
 from .wavlm import WavLM, WavLMConfig
 from huggingface_hub import PyTorchModelHubMixin
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logging = logging.getLogger(__name__)
 
 
 DEFAULT_AUDIO_CFG = WavLMConfig(

--- a/src/audiobox_aesthetics/utils.py
+++ b/src/audiobox_aesthetics/utils.py
@@ -16,9 +16,7 @@ DEFAULT_HF_REPO = "facebook/audiobox-aesthetics"
 DEFAULT_CKPT_FNAME = "checkpoint.pt"
 DEFAULT_S3_URL = "https://dl.fbaipublicfiles.com/audiobox-aesthetics/checkpoint.pt"
 
-
-logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
-
+logging = logging.getLogger(__name__)
 
 def download_file(url, destination):
     """Download a file from a URL with a progress bar."""


### PR DESCRIPTION
Currently modules such as infer.py were resetting the logging configuration. This messes with importers who want to use infer.py in their own code. Instead initialize module-specific loggers.